### PR TITLE
fix sip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `mapproj` Change Log
 
+## 0.4.1
+
+### Add
+
+* Fix SIP support
 
 ## 0.4.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapproj"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["F.-X. Pineau <francois-xavier.pineau@astro.unistra.fr>"]
 description = "Implementation of (a part of) map projections defined in the FITS World Coordinate System (WCS)"

--- a/src/img2proj.rs
+++ b/src/img2proj.rs
@@ -357,9 +357,12 @@ pub struct WcsWithSipProjXY2ImgXY {
 impl ProjXY2ImgXY for WcsWithSipProjXY2ImgXY {
 
   fn proj2img(&self, xy: &ProjXY) -> Option<ImgXY> {
-    let x = self.wcs.icd11 * xy.x + self.wcs.icd12 * xy.y + self.wcs.crpix1;
-    let y = self.wcs.icd21 * xy.x + self.wcs.icd22 * xy.y + self.wcs.crpix2;
-    self.sip.inverse(x, y).map(|ImgXY{x: rx, y: ry}| ImgXY::new(x + rx, y + ry))
+    let bu = self.wcs.icd11 * xy.x + self.wcs.icd12 * xy.y;
+    let bv = self.wcs.icd21 * xy.x + self.wcs.icd22 * xy.y;
+    self
+      .sip
+      .inverse(bu, bv)
+      .map(|ImgXY { x: rx, y: ry }| ImgXY::new(bu + rx + self.wcs.crpix1, bv + ry + self.wcs.crpix2))
   }
 }
 

--- a/src/sip.rs
+++ b/src/sip.rs
@@ -36,19 +36,18 @@ impl SipCoeff {
   
   /// Returns the value of the polynomial, evaluated in `(u, v)`.
   pub fn p(&self, u: f64, v: f64) -> f64 {
-    // Probably not the most efficient way to implement this. TODO: think twice...
     let mut k = 0;
     let mut p = 0_f64;
-    let mut x = u;
+    let mut x = 1_f64;         // u^i, starting at u^0
     for i in 0..self.order {
       let l = self.order - i;
-      let mut y = v;
+      let mut y = 1_f64;       // v^j, reset each outer loop
       for _ in 0..l {
         p += x * y * self.c[k];
         k += 1;
-        y *= y; // Not optimal for numerical stability :o/
+        y *= v;                // advance v^j linearly
       }
-      x *= x; // Not optimal for numerical stability :o/
+      x *= u;                  // advance u^i linearly
     }
     debug_assert_eq!(k, self.c.len());
     p
@@ -56,19 +55,18 @@ impl SipCoeff {
 
   /// Returns the value of the `dp/du`, evaluated in `(u, v)`.
   pub fn dpdu(&self, u: f64, v: f64) -> f64 {
-    // Probably not the most efficient way to implement this. TODO: think twice...
     let mut k = 0;
     let mut p = 0_f64;
-    let mut x = u;
-    for i in 1..self.order {
+    let mut x = 1_f64;
+    for i in 0..self.order {
       let l = self.order - i;
-      let mut y = v;
+      let mut y = 1_f64;
       for _ in 0..l {
-        p += i as f64 * x * y * self.c[k];
+        p += f64::from(i) * x * y * self.c[k];
         k += 1;
-        y *= y; // Not optimal for numerical stability :o/
+        y *= v;
       }
-      x *= x; // Not optimal for numerical stability :o/
+      x *= u;
     }
     debug_assert_eq!(k, self.c.len());
     p
@@ -76,19 +74,18 @@ impl SipCoeff {
 
   /// Returns the value of the `dp/dv`, evaluated in `(u, v)`.
   pub fn dpdv(&self, u: f64, v: f64) -> f64 {
-    // Probably not the most efficient way to implement this. TODO: think twice...
     let mut k = 0;
     let mut p = 0_f64;
-    let mut x = u;
+    let mut x = 1_f64;           // u^i
     for i in 0..self.order {
       let l = self.order - i;
-      let mut y = v;
-      for j in 1..l {
-        p += j as f64 * x * y * self.c[k];
+      let mut y = 1_f64;       // v^(j-1), starting at v^0 when j=1
+      for j in 0..l {
+        p += f64::from(j) * x * y * self.c[k];
         k += 1;
-        y *= y; // Not optimal for numerical stability :o/
+        y *= v;
       }
-      x *= x; // Not optimal for numerical stability :o/
+      x *= u;
     }
     debug_assert_eq!(k, self.c.len());
     p
@@ -222,8 +219,8 @@ impl Sip {
       None
     }
   }
-  
-  /// Mutli-variate Newton-Raphson:
+
+  /// Multi-variate Newton-Raphson:
   /// f1(x1, ..., xn) = 0es006500
   /// ...
   /// fn(x1, ..., xn) = 0


### PR DESCRIPTION
This do some fixes on the SIP support that suffers from maybe problems:
* in the `p(x, y)` evaluation and its derivatives
* in the `inverse` method where the crpix offset was applied at the wrong place

Newton-Raphson has not been tested here.